### PR TITLE
Add endpoints

### DIFF
--- a/backend/app/api/routes/cleanings.py
+++ b/backend/app/api/routes/cleanings.py
@@ -3,8 +3,11 @@ from typing import List
 from fastapi import APIRouter
 from fastapi import Body
 from fastapi import Depends
+from fastapi import HTTPException
 
-from starlette.status import HTTP_201_CREATED
+from starlette.status import HTTP_200_OK  # TODO: swap starlette for fastapi
+from starlette.status import HTTP_201_CREATED  # TODO: swap starlette for fastapi
+from starlette.status import HTTP_404_NOT_FOUND  # TODO: swap starlette for fastapi
 
 from app.models.cleaning import CleaningCreate
 from app.models.cleaning import CleaningPublic
@@ -31,3 +34,15 @@ async def create_new_cleaning(
     created_cleaning = await cleanings_repo.create_cleaning(new_cleaning=new_cleaning)
 
     return created_cleaning
+
+
+@router.get('/{id}/', response_model=CleaningPublic, name='cleanings:get-cleaning-by-id')
+async def get_cleaning_by_id(
+    id: int, cleanings_repo: CleaningsRepository = Depends(get_repository(CleaningsRepository))
+) -> CleaningPublic:
+    cleaning = await cleanings_repo.get_cleaning_by_id(id=id)
+
+    if not cleaning:
+        raise HTTPException(status_code=HTTP_404_NOT_FOUND, detail='No cleaning found with that id.')
+    
+    return cleaning

--- a/backend/app/db/migrations/env.py
+++ b/backend/app/db/migrations/env.py
@@ -43,7 +43,7 @@ def run_migrations_online() -> None:
             default_conn.execute(f'CREATE DATABASE {POSTGRES_DB}{db_suffix}')
 
     connectable = config.attributes.get('connection', None)
-    config.set_main_option('sqlalchemy.url', str(DATABASE_URL))
+    config.set_main_option('sqlalchemy.url', str(db_url))
 
     if connectable is None:
         connectable = engine_from_config(

--- a/backend/app/db/repositories/cleanings.py
+++ b/backend/app/db/repositories/cleanings.py
@@ -10,6 +10,12 @@ CREATE_CLEANING_QUERY = """
     RETURNING id, name, description, price, cleaning_type;
 """
 
+GET_CLEANING_BY_ID_QUERY = """
+    SELECT id, name, description, price, cleaning_type
+    FROM cleanings
+    WHERE id = :id;
+"""
+
 class CleaningsRepository(BaseRepository):
     '''
     All database actions associated with the Cleaning resource
@@ -17,5 +23,14 @@ class CleaningsRepository(BaseRepository):
     async def create_cleaning(self, *, new_cleaning: CleaningCreate) -> CleaningInDB:
         query_values = new_cleaning.dict()
         cleaning = await self.db.fetch_one(query=CREATE_CLEANING_QUERY, values=query_values)
+
+        return CleaningInDB(**cleaning)
+    
+
+    async def get_cleaning_by_id(self, *, id: int) -> CleaningInDB:
+        cleaning = await self.db.fetch_one(query=GET_CLEANING_BY_ID_QUERY, values={'id': id})
+
+        if not cleaning:
+            return None
 
         return CleaningInDB(**cleaning)

--- a/backend/app/db/tasks.py
+++ b/backend/app/db/tasks.py
@@ -1,3 +1,4 @@
+import os
 from fastapi import FastAPI
 from databases import Database
 from app.core.config import DATABASE_URL
@@ -8,7 +9,8 @@ logger = logging.getLogger(__name__)
 
 
 async def connect_to_db(app: FastAPI) -> None:
-    database = Database(DATABASE_URL, min_size=2, max_size=10)  # these can be configured in config.py as well
+    db_url = f"""{DATABASE_URL}{os.environ.get('DB_SUFFIX', '')}"""
+    database = Database(db_url, min_size=2, max_size=10)  # these can be configured in config.py as well
 
     try:
         await database.connect()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,7 +3,16 @@ fastapi==0.55.1
 uvicorn==0.11.3
 pydantic==1.4
 email-validator==1.1.1
+
 # db
 databases[postgresql]==0.3.1
 SQLAlchemy==1.3.16
 alembic==1.4.2
+
+# dev
+pytest==5.4.2
+pytest-asyncio==0.12.0
+pytest-xdist==1.32.0
+httpx==0.12.1
+asgi-lifespan==1.0.0
+docker==4.2.0

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -13,6 +13,10 @@ from databases import Database
 import alembic
 from alembic.config import Config
 
+from app.models.cleaning import CleaningCreate
+from app.models.cleaning import CleaningInDB
+from app.db.repositories.cleanings import CleaningsRepository
+
 
 @pytest.fixture(scope='session')
 def docker() -> pydocker.APIClient:
@@ -81,3 +85,16 @@ async def client(app: FastAPI) -> AsyncClient:
             headers={'Content-Type': 'application/json'}
         ) as client:
             yield client
+
+
+@pytest.fixture
+async def test_cleaning(db: Database) -> CleaningInDB:
+    cleaning_repo = CleaningsRepository(db)
+    new_cleaning = CleaningCreate(
+        name='fake cleaning name',
+        description='fake cleaning description',
+        price=9.99,
+        cleaning_type='spot_clean',
+    )
+
+    return await cleaning_repo.create_cleaning(new_cleaning=new_cleaning)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -17,7 +17,7 @@ from alembic.config import Config
 @pytest.fixture(scope='session')
 def docker() -> pydocker.APIClient:
     # base url is the unix socket we use to communicate with docker
-    return pydocker.APIClient(base_url='unix://var/run/docker/sock', version='auto')
+    return pydocker.APIClient(base_url='unix://var/run/docker.sock', version='auto')
 
 
 @pytest.fixture(scope='session', autouse=True)
@@ -29,7 +29,7 @@ def postgres_container(docker: pydocker.APIClient) -> None:
 
     DB actions persist across the entirety of the testing session.
     '''
-    warnings.filterwarnings('ignore', category=DepracationWarning)
+    warnings.filterwarnings('ignore', category=DeprecationWarning)
 
     # pull image from docker
     image = 'postgres:12.1-alpine'

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,83 @@
+import warnings
+import uuid
+import os
+
+import pytest
+import docker as pydocker
+from asgi_lifespan import LifespanManager
+
+from fastapi import FastAPI
+from httpx import AsyncClient
+from databases import Database
+
+import alembic
+from alembic.config import Config
+
+
+@pytest.fixture(scope='session')
+def docker() -> pydocker.APIClient:
+    # base url is the unix socket we use to communicate with docker
+    return pydocker.APIClient(base_url='unix://var/run/docker/sock', version='auto')
+
+
+@pytest.fixture(scope='session', autouse=True)
+def postgres_container(docker: pydocker.APIClient) -> None:
+    '''
+    Use docker to spin up a postgres container for the duration of the testing session.
+
+    Kill it as soon as all tests are run.
+
+    DB actions persist across the entirety of the testing session.
+    '''
+    warnings.filterwarnings('ignore', category=DepracationWarning)
+
+    # pull image from docker
+    image = 'postgres:12.1-alpine'
+    docker.pull(image)
+
+    # create the new container using the same image used by our database
+    container = docker.create_container(
+        image=image,
+        name=f'test-postgres-{uuid.uuid4()}',
+        detach=True,
+    )
+
+    docker.start(container=container['Id'])
+
+    config = alembic.config.Config('alembic.ini')
+
+    try:
+        os.environ['DB_SUFFIX'] = '_test'
+        alembic.command.upgrade(config, 'head')
+        yield container
+        alembic.command.downgrade(config, 'base')
+    finally:
+        # remove container
+        docker.kill(container['Id'])
+        docker.remove_container(container['Id'])
+
+
+# Create a new application for testing
+@pytest.fixture
+def app() -> FastAPI:
+    from app.api.server import get_application
+
+    return get_application()
+
+
+# Grab a reference to our database when needed
+@pytest.fixture
+def db(app: FastAPI) -> Database:
+    return app.state._db
+
+
+# Make requests in our tests
+@pytest.fixture
+async def client(app: FastAPI) -> AsyncClient:
+    async with LifespanManager(app):
+        async with AsyncClient(
+            app=app,
+            base_url='http://testserver',
+            headers={'Content-Type': 'application/json'}
+        ) as client:
+            yield client

--- a/backend/tests/test_cleanings.py
+++ b/backend/tests/test_cleanings.py
@@ -5,15 +5,40 @@ from fastapi import FastAPI
 
 from starlette.status import HTTP_404_NOT_FOUND  # TODO: swap starlette for fastapi
 from starlette.status import HTTP_422_UNPROCESSABLE_ENTITY  # TODO: swap starlette for fastapi
+from starlette.status import HTTP_201_CREATED  # TODO: swap starlette for fastapi
 
+from app.models.cleaning import CleaningCreate
+
+# decorate all tests with @pytest.mark.asyncio
+pytestmark = pytest.mark.asyncio
+
+@pytest.fixture
+def new_cleaning():
+    return CleaningCreate(
+        name='test cleaning',
+        description='test description',
+        price=0.00,
+        cleaning_type='spot_clean',
+    )
 
 class TestCleaningsRoutes:
-    @pytest.mark.asyncio
     async def test_routes_exist(self, app: FastAPI, client: AsyncClient) -> None:
         res = await client.post(app.url_path_for('cleanings:create-cleaning'), json={})
         assert res.status_code != HTTP_404_NOT_FOUND
 
-    @pytest.mark.asyncio
     async def test_invalid_input_raises_error(self, app: FastAPI, client: AsyncClient) -> None:
         res = await client.post(app.url_path_for('cleanings:create-cleaning'), json={})
-        assert res.status_code != HTTP_422_UNPROCESSABLE_ENTITY
+        assert res.status_code == HTTP_422_UNPROCESSABLE_ENTITY
+
+
+class TestCreateCleaning:
+    async def test_valid_input_creates_cleaning(
+        self, app: FastAPI, client: AsyncClient, new_cleaning: CleaningCreate
+    ) -> None:
+        res = await client.post(
+            app.url_path_for('cleanings:create-cleaning'), json={'new_cleaning': new_cleaning.dict()}
+        )
+        assert res.status_code == HTTP_201_CREATED
+
+        created_cleaning = CleaningCreate(**res.json())
+        assert created_cleaning == new_cleaning

--- a/backend/tests/test_cleanings.py
+++ b/backend/tests/test_cleanings.py
@@ -1,0 +1,19 @@
+import pytest
+
+from httpx import AsyncClient
+from fastapi import FastAPI
+
+from starlette.status import HTTP_404_NOT_FOUND  # TODO: swap starlette for fastapi
+from starlette.status import HTTP_422_UNPROCESSABLE_ENTITY  # TODO: swap starlette for fastapi
+
+
+class TestCleaningsRoutes:
+    @pytest.mark.asyncio
+    async def test_routes_exist(self, app: FastAPI, client: AsyncClient) -> None:
+        res = await client.post(app.url_path_for('cleanings:create-cleaning'), json={})
+        assert res.status_code != HTTP_404_NOT_FOUND
+
+    @pytest.mark.asyncio
+    async def test_invalid_input_raises_error(self, app: FastAPI, client: AsyncClient) -> None:
+        res = await client.post(app.url_path_for('cleanings:create-cleaning'), json={})
+        assert res.status_code != HTTP_422_UNPROCESSABLE_ENTITY

--- a/backend/tests/test_cleanings.py
+++ b/backend/tests/test_cleanings.py
@@ -3,11 +3,13 @@ import pytest
 from httpx import AsyncClient
 from fastapi import FastAPI
 
+from starlette.status import HTTP_200_OK  # TODO: swap starlette for fastapi
+from starlette.status import HTTP_201_CREATED  # TODO: swap starlette for fastapi
 from starlette.status import HTTP_404_NOT_FOUND  # TODO: swap starlette for fastapi
 from starlette.status import HTTP_422_UNPROCESSABLE_ENTITY  # TODO: swap starlette for fastapi
-from starlette.status import HTTP_201_CREATED  # TODO: swap starlette for fastapi
 
 from app.models.cleaning import CleaningCreate
+from app.models.cleaning import CleaningInDB
 
 # decorate all tests with @pytest.mark.asyncio
 pytestmark = pytest.mark.asyncio
@@ -60,3 +62,11 @@ class TestCreateCleaning:
             app.url_path_for('cleanings:create-cleaning'), json={'new_cleaning': invalid_payload}
         )
         assert res.status_code == status_code
+
+
+class TestGetCleaning:
+    async def test_get_cleaning_by_id(self, app: FastAPI, client: AsyncClient) -> None:
+        res = await client.get(app.url_path_for('cleanings:get-cleaning-by-id', id=1))
+        assert res.status_code == HTTP_200_OK
+        cleaning = CleaningInDB(**res.json())
+        assert cleaning.id == 1

--- a/backend/tests/test_cleanings.py
+++ b/backend/tests/test_cleanings.py
@@ -42,3 +42,21 @@ class TestCreateCleaning:
 
         created_cleaning = CleaningCreate(**res.json())
         assert created_cleaning == new_cleaning
+
+    @pytest.mark.parametrize(
+        'invalid_payload, status_code',
+        (
+            (None, 422),
+            ({}, 422),
+            ({'name': 'test_name'}, 422),
+            ({'price': 10.00}, 422),
+            ({'name': 'test_name', 'description': 'test'}, 422),
+        ),
+    )
+    async def test_invalid_input_raises_error(
+        self, app: FastAPI, client: AsyncClient, invalid_payload: dict, status_code: int
+    ) -> None:
+        res = await client.post(
+            app.url_path_for('cleanings:create-cleaning'), json={'new_cleaning': invalid_payload}
+        )
+        assert res.status_code == status_code

--- a/backend/tests/test_cleanings.py
+++ b/backend/tests/test_cleanings.py
@@ -65,8 +65,24 @@ class TestCreateCleaning:
 
 
 class TestGetCleaning:
-    async def test_get_cleaning_by_id(self, app: FastAPI, client: AsyncClient) -> None:
-        res = await client.get(app.url_path_for('cleanings:get-cleaning-by-id', id=1))
+    async def test_get_cleaning_by_id(self, app: FastAPI, client: AsyncClient, test_cleaning: CleaningInDB) -> None:
+        res = await client.get(app.url_path_for('cleanings:get-cleaning-by-id', id=test_cleaning.id))
         assert res.status_code == HTTP_200_OK
         cleaning = CleaningInDB(**res.json())
-        assert cleaning.id == 1
+        assert cleaning == test_cleaning
+
+
+    @pytest.mark.parametrize(
+        'id, status_code',
+        (
+            (500, 404),
+            (-1, 404),
+            (None, 422),
+            ('asdf', 422),
+        ),
+    )
+    async def test_wrong_id_returns_error(
+        self, app: FastAPI, client: AsyncClient, id: int, status_code: int
+    ) -> None:
+        res = await client.get(app.url_path_for('cleanings:get-cleaning-by-id', id=id))
+        assert res.status_code == status_code


### PR DESCRIPTION
## Stories/Task Links:
Closes: None

**Description:**
This PR adds:
* Get cleaning by id
* Tests
* Pytest configuration
* Pytest now spins up a new Docker container for each testing session with a fresh postgres database
* Test queries execute against the test db and persist for the duration of the testing session

## What did you struggle on to complete?
I was blocked by my test database not being created. It was due to an error where I assigned `db_user` as the db_name plus the db_suffix in the environment variables. Instead of passing in `db_user`, I was just passing in the db_name without the suffix.


## Current Test Suite:
### Test Coverage Percentage: 100%
- [ ] No Tests have been changed
- [x] Some Tests have been added
- [ ] All of the Tests have been changed(Please describe):

## Checklist:
- [x] My code has no unused/commented out code
- [x] I have reviewed my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have fully tested my code
- [ ] I have partially tested my code (please explain):

## Helpful Resources:
* Tutorial section: https://www.jeffastor.com/blog/testing-fastapi-endpoints-with-docker-and-pytest
* Excellent testing examples which the tutorial drew inspiration from: https://github.com/nsidnev/fastapi-realworld-example-app