### PR TITLE
User authentication

### DIFF
--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -12,6 +12,10 @@ from app.api.dependencies.database import get_repository
 from app.models.user import UserCreate
 from app.models.user import UserPublic
 
+from app.models.token import AccessToken
+
+from app.services import auth_service
+
 from app.db.repositories.users import UsersRepository
 
 router = APIRouter()
@@ -23,4 +27,8 @@ async def register_new_user(
 ) -> UserPublic:
     created_user = await user_repo.register_new_user(new_user=new_user)
 
-    return created_user
+    access_token = AccessToken(
+        access_token=auth_service.create_access_token_for_user(user=created_user), token_type='bearer'
+    )
+
+    return UserPublic(**created_user.dict(), access_token=access_token)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -8,7 +8,16 @@ PROJECT_NAME = 'phresh'
 VERSION = '1.0.0'
 API_PREFIX = '/api'
 
-SECRET_KEY = config('SECRET_KEY', cast=Secret, default='CHANGEME')
+SECRET_KEY = config('SECRET_KEY', cast=Secret)
+
+ACCESS_TOKEN_EXPIRE_MINUTES = config(
+    'ACCESS_TOKEN_EXPIRE_MINUTES',
+    cast=int,
+    default=7 * 24 * 60  # one week
+)
+JWT_ALGORITHM = config('JWT_ALGORITHM', cast=str, default='HS256')
+JWT_AUDIENCE = config('JWT_AUDIENCE', cast=str, default='phresh:auth')
+JWT_TOKEN_PREFIX = config('JWT_TOKEN_PREFIX', cast=str, default='Bearer')
 
 POSTGRES_USER = config('POSTGRES_USER', cast=str)
 POSTGRES_PASSWORD = config('POSTGRES_PASSWORD', cast=Secret)

--- a/backend/app/db/repositories/users.py
+++ b/backend/app/db/repositories/users.py
@@ -3,11 +3,15 @@ from pydantic import EmailStr
 from fastapi import HTTPException
 from fastapi import status
 
+from databases import Database
+
 from app.db.repositories.base import BaseRepository
 
 from app.models.user import UserCreate
 from app.models.user import UserUpdate
 from app.models.user import UserInDB
+
+from app.services import auth_service
 
 
 GET_USER_BY_EMAIL_QUERY = """
@@ -30,6 +34,11 @@ REGISTER_NEW_USER_QUERY = """
 
 
 class UsersRepository(BaseRepository):
+
+    def __init__(self, db: Database) -> None:
+        super().__init__(db)
+        self.auth_service = auth_service
+
     async def get_user_by_email(self, *, email: EmailStr) -> UserInDB:
         user_record = await self.db.fetch_one(query=GET_USER_BY_EMAIL_QUERY, values={'email': email})
 
@@ -62,6 +71,9 @@ class UsersRepository(BaseRepository):
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail='That username is already taken. Please try another one.'
             )
-        created_user = await self.db.fetch_one(query=REGISTER_NEW_USER_QUERY, values={**new_user.dict(), 'salt': '123'})
+
+        user_password_update = self.auth_service.create_salt_and_hashed_password(plaintext_password=new_user.password)
+        new_user_params = new_user.copy(update=user_password_update.dict())
+        created_user = await self.db.fetch_one(query=REGISTER_NEW_USER_QUERY, values=new_user_params.dict())
 
         return UserInDB(**created_user)

--- a/backend/app/models/core.py
+++ b/backend/app/models/core.py
@@ -17,7 +17,7 @@ class DateTimeModelMixin(BaseModel):
 
     @validator('created_at', 'updated_at', pre=True)
     def default_datetime(cls, value: datetime) -> datetime:
-        return value or datetime.datetime.now()
+        return value or datetime.now()
 
 
 class IDModelMixin(BaseModel):

--- a/backend/app/models/token.py
+++ b/backend/app/models/token.py
@@ -1,0 +1,34 @@
+from datetime import datetime
+from datetime import timedelta
+
+from pydantic import EmailStr
+
+from app.core.config import JWT_AUDIENCE
+from app.core.config import ACCESS_TOKEN_EXPIRE_MINUTES
+
+from app.models.core import CoreModel
+
+
+class JWTMeta(CoreModel):
+    iss: str = 'phresh.io'
+    aud: str = JWT_AUDIENCE
+    iat: float = datetime.timestamp(datetime.utcnow())
+    exp: float = datetime.timestamp(datetime.utcnow() + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES))
+
+
+class JWTCreds(CoreModel):
+    '''How we'll identify users'''
+    sub: EmailStr
+    username: str
+
+
+class JWTPayload(JWTMeta, JWTCreds):
+    '''
+    JWT Payload right before it's encoded - combine meta and username
+    '''
+    pass
+
+
+class AccessToken(CoreModel):
+    access_token: str
+    token_type: str

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -64,7 +64,7 @@ class UserPasswordUpdate(CoreModel):
     salt: str
 
 
-class UserInDB(IDModelMixin, UserBase):
+class UserInDB(IDModelMixin, DateTimeModelMixin, UserBase):
     password: constr(min_length=7, max_length=100)
     salt: str
 

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -9,6 +9,8 @@ from app.models.core import DateTimeModelMixin
 from app.models.core import IDModelMixin
 from app.models.core import CoreModel
 
+from app.models.token import AccessToken
+
 
 #  simple check for valid username
 def validate_username(username: str) -> str:
@@ -68,4 +70,4 @@ class UserInDB(IDModelMixin, UserBase):
 
 
 class UserPublic(IDModelMixin, DateTimeModelMixin, UserBase):
-    pass
+    access_token: Optional[AccessToken]

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,0 +1,3 @@
+from app.services.authentication import AuthService
+
+auth_service = AuthService()

--- a/backend/app/services/authentication.py
+++ b/backend/app/services/authentication.py
@@ -1,0 +1,33 @@
+import bcrypt
+from passlib.context import CryptContext
+
+from app.models.user import UserPasswordUpdate
+
+pwd_context = CryptContext(schemes=['bcrypt'], deprecated='auto')
+
+
+class AuthException(BaseException):
+    '''
+    Custom auth exception that can be modified later on.
+    '''
+    pass
+
+
+class AuthService:
+    def create_salt_and_hashed_password(self, *, plaintext_password: str) -> UserPasswordUpdate:
+        salt = self.generate_salt()
+        hashed_password = self.hash_password(password=plaintext_password, salt=salt)
+
+        return UserPasswordUpdate(salt=salt, password=hashed_password)
+
+
+    def generate_salt(self) -> str:
+        return bcrypt.gensalt().decode()
+
+
+    def hash_password(self, *, password: str, salt: str) -> str:
+        return pwd_context.hash(password + salt)
+
+
+    def verify_password(self, *, password: str, salt: str, hashed_pw: str) -> bool:
+        return pwd_context.verify(password + salt, hashed_pw)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,6 +9,10 @@ databases[postgresql]==0.3.1
 SQLAlchemy==1.3.16
 alembic==1.4.2
 
+# auth
+pyjwt==1.7.1
+passlib[bcrypt]==1.7.2
+
 # dev
 pytest==5.4.2
 pytest-asyncio==0.12.0

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -15,7 +15,11 @@ from alembic.config import Config
 
 from app.models.cleaning import CleaningCreate
 from app.models.cleaning import CleaningInDB
+from app.models.user import UserCreate
+from app.models.user import UserInDB
+
 from app.db.repositories.cleanings import CleaningsRepository
+from app.db.repositories.users import UsersRepository
 
 
 @pytest.fixture(scope='session')
@@ -98,3 +102,20 @@ async def test_cleaning(db: Database) -> CleaningInDB:
     )
 
     return await cleaning_repo.create_cleaning(new_cleaning=new_cleaning)
+
+
+@pytest.fixture
+async def test_user(db: Database) -> UserInDB:
+    new_user = UserCreate(
+        email='lebron@james.io',
+        username='lebronjames',
+        password='heatcavslakers',
+    )
+
+    user_repo = UsersRepository(db)
+
+    existing_user = await user_repo.get_user_by_email(email=new_user.email)
+    if existing_user:
+        return existing_user
+
+    return await user_repo.register_new_user(new_user=new_user)

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -76,7 +76,7 @@ class TestUserRegistration:
         assert user_in_db.username == new_user['username']
 
         # check that the user returned in the response is equal to the user in the database
-        created_user = UserPublic(**res.json()).dict(exclude={'access_token', 'created_at', 'updated_at'})
+        created_user = UserPublic(**res.json()).dict(exclude={'access_token'})
         assert created_user == user_in_db.dict(exclude={'password', 'salt'})
     
     @pytest.mark.parametrize(

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -17,6 +17,8 @@ from app.models.user import UserInDB
 
 from app.db.repositories.users import UsersRepository
 
+from app.services import auth_service
+
 pytestmark = pytest.mark.asyncio
 
 
@@ -81,3 +83,29 @@ class TestUserRegistration:
 
         res = await client.post(app.url_path_for('users:register-new-user'), json={'new_user': new_user})
         assert res.status_code == status_code
+
+
+    async def test_users_saved_password_is_hashed_and_has_salt(
+        self,
+        app: FastAPI,
+        client: AsyncClient,
+        db: Database,
+    ) -> None:
+        user_repo = UsersRepository(db)
+        new_user = {'email': 'beyonce@knowles.io', 'username': 'queenbey', 'password': 'destinyschild'}
+
+        # send post request to create user and ensure it is successful
+        res = await client.post(app.url_path_for('users:register-new-user'), json={'new_user': new_user})
+        assert res.status_code == HTTP_201_CREATED
+
+        # ensure the user password is hashed in the db
+        # and that we can verify it using our auth service
+        user_in_db = await user_repo.get_user_by_email(email=new_user['email'])
+        assert user_in_db is not None
+        assert user_in_db.salt is not None and user_in_db.salt != '123'
+        assert user_in_db.password != new_user['password']
+        assert auth_service.verify_password(
+            password=new_user['password'],
+            salt=user_in_db.salt,
+            hashed_pw=user_in_db.password,
+        )

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -34,6 +34,7 @@ from app.models.token import JWTCreds
 from app.models.token import JWTPayload
 from app.models.user import UserCreate
 from app.models.user import UserInDB
+from app.models.user import UserPublic
 
 from app.db.repositories.users import UsersRepository
 
@@ -75,7 +76,7 @@ class TestUserRegistration:
         assert user_in_db.username == new_user['username']
 
         # check that the user returned in the response is equal to the user in the database
-        created_user = UserInDB(**res.json(), password='whatever', salt='123').dict(exclude={'password', 'salt'})
+        created_user = UserPublic(**res.json()).dict(exclude={'access_token', 'created_at', 'updated_at'})
         assert created_user == user_in_db.dict(exclude={'password', 'salt'})
     
     @pytest.mark.parametrize(


### PR DESCRIPTION
## What functionality does this accomplish?
Closes: None

**Description:**
This PR:
* Adds user authentication (registration)
* Adds token-building logic
* Adds token into user registration step

## What did you struggle on to complete?
* `test_users_can_register_successfully`: I had to modify a test in the tutorial. UserPublic model returns the `created_at` and `updated_at` fields, but the `user_repo.get_user_by_email` method was not returning those two fields. My plan is to look at this again (specifically why `get_user_by_email` isn't returning these fields. I'll hold off from merging until I get a chance to look into these more.
  * The problem above was that I wasn't passing in DateTimeMixin to UserInDB, so UserInDB wasn't passing forward `created_at` and `updated_at`. 

## Current Test Suite:
### Test Coverage Percentage: x%
- [ ] No Tests have been changed
- [x] Some Tests have been added
- [ ] All of the Tests have been changed(Please describe):

## Checklist:
- [x] My code has no unused/commented out code
- [x] I have reviewed my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have fully tested my code
- [ ] I have partially tested my code (please explain):

## Helpful Resources:
* Tutorial section: https://www.jeffastor.com/blog/authenticating-users-in-fastapi-with-jwt-tokens